### PR TITLE
update build to nomad version 0.6.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: bin image push release clean
 
 TAG=vancluever/nomad
-VERSION=0.5.6
+VERSION=0.6.3
 
 bin:
 	rm -rf 0.X/pkg


### PR DESCRIPTION
1. `make release` for this version works for me
2. nomad docker seems to start up just fine.
